### PR TITLE
Change access modifier of CollectionChanged to public

### DIFF
--- a/ObservableCollectionEx/ObservableCollectionEx.cs
+++ b/ObservableCollectionEx/ObservableCollectionEx.cs
@@ -121,7 +121,7 @@ namespace System.Collections.ObjectModel
 #if FRAMEWORK
         [field: NonSerialized]
 #endif
-        protected virtual event NotifyCollectionChangedEventHandler CollectionChanged = _emptyDelegate;
+        public virtual event NotifyCollectionChangedEventHandler CollectionChanged = _emptyDelegate;
 
         #endregion Protected Fields
 


### PR DESCRIPTION
Hi, thanks for your work! I just noticed that the `CollectionChanged` event is set to `private`, but it's `public` in [ObservableCollection](https://github.com/dotnet/runtime/blob/e5ed253e38d3bf1414949924e1e69f43c8164d1b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs#L84). 
